### PR TITLE
chore: make package private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "zopio",
   "version": "0.9.0",
+  "private": true,
   "bin": {
     "zopio": "dist/index.js"
   },
-  "files": [
-    "dist/index.js"
-  ],
+  "files": ["dist/index.js"],
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",


### PR DESCRIPTION
## Summary
- Added `"private": true` to root package.json to prevent accidental npm publication

## Test plan
- [x] Verify package.json has private field set to true
- [x] Confirm this prevents npm publish